### PR TITLE
Add tests for Bourgeois::ViewHelper

### DIFF
--- a/lib/bourgeois.rb
+++ b/lib/bourgeois.rb
@@ -4,10 +4,16 @@ require 'delegate'
 require 'active_model'
 require 'action_view'
 
+require 'bourgeois/errors'
 require 'bourgeois/presenter'
 require 'bourgeois/view_helper'
 
 module Bourgeois
+  def self.inject_into_action_view
+    @inject_into_action_view ||= Proc.new do
+      ActionView::Base.send(:include, ViewHelper)
+    end
+  end
 end
 
 require 'bourgeois/railtie' if defined?(Rails) && Rails::VERSION::MAJOR >= 3

--- a/lib/bourgeois/errors.rb
+++ b/lib/bourgeois/errors.rb
@@ -1,0 +1,11 @@
+module Bourgeois
+  class UnknownPresenter < StandardError
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def to_s
+      "unknown presenter class #{@klass}"
+    end
+  end
+end

--- a/lib/bourgeois/railtie.rb
+++ b/lib/bourgeois/railtie.rb
@@ -4,9 +4,7 @@ require 'rails'
 module Bourgeois
   class Railtie < Rails::Railtie
     initializer 'bourgeois.action_view' do |app|
-      ActiveSupport.on_load :action_view do
-        ActionView::Base.send(:include, ViewHelper)
-      end
+      ActiveSupport.on_load :action_view, {}, &Bourgeois.inject_into_action_view
     end
   end
 end

--- a/lib/bourgeois/view_helper.rb
+++ b/lib/bourgeois/view_helper.rb
@@ -1,6 +1,6 @@
 module Bourgeois
   module ViewHelper
-    # Wrap a resource or a collection into its related delegator
+    # Wrap a resource or a collection into its related presenter
     #
     # @example
     #   present User.new(name: 'Remi') do |user|
@@ -10,7 +10,15 @@ module Bourgeois
     def present(object, klass = nil, &blk)
       return object.map { |o| present(o, klass, &blk) } if object.respond_to?(:to_a)
 
-      klass ||= "#{object.class}Presenter".constantize
+      if klass.blank?
+        begin
+          klass_name = "#{object.class}Presenter"
+          klass = klass_name.constantize
+        rescue ::NameError
+          raise UnknownPresenter.new(klass_name)
+        end
+      end
+
       presenter = klass.new(object, self)
       yield presenter if block_given?
 

--- a/spec/bourgeois/view_helper_spec.rb
+++ b/spec/bourgeois/view_helper_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Bourgeois::ViewHelper do
+  describe :present do
+    let(:view) { ActionView::Base.new }
+
+    before do
+      class UserPresenter < Bourgeois::Presenter
+        def formatted_name
+          "#{first_name} #{last_name}".strip
+        end
+      end
+
+      class User < OpenStruct; end
+    end
+
+    context 'on a single resource' do
+      let(:user) { User.new first_name: 'Patrick', last_name: 'Bourgeois' }
+
+      context 'without a block' do
+        it { expect(view.present(user).formatted_name).to eql 'Patrick Bourgeois' }
+      end
+
+      context 'with a block' do
+        specify do
+          view.present(user) do |u|
+            expect(u.formatted_name).to eql 'Patrick Bourgeois'
+          end
+        end
+      end
+    end
+
+    context 'on a collection of resources' do
+      let(:user1) { User.new first_name: 'Patrick', last_name: 'Bourgeois' }
+      let(:user2) { User.new first_name: 'Francois', last_name: 'Jean' }
+      let(:user3) { User.new first_name: 'Alain', last_name: 'Lapointe' }
+      let(:users) { [user1, user2, user3] }
+
+      specify do
+        output = []
+        view.present(users) { |u| output << u.formatted_name }
+
+        expect(output).to eql ['Patrick Bourgeois', 'Francois Jean', 'Alain Lapointe']
+      end
+    end
+
+    context 'on a resource without a defined presenter class' do
+      before do
+        class Project < OpenStruct; end
+      end
+
+      let(:project) { Project.new name: 'Les B.B.' }
+      it { expect { view.present(project) }.to raise_error(Bourgeois::UnknownPresenter, 'unknown presenter class ProjectPresenter') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,5 @@ require 'ostruct'
 require 'rspec'
 require 'bourgeois'
 
-RSpec.configure do |config|
-end
+# Inject our helper into ActionView
+ActionView::Base.class_eval(&Bourgeois.inject_into_action_view)


### PR DESCRIPTION
It was kind of silly to have tests for `Presenter` and nothing for `ViewHelper`, since one of Bourgeois’ core features is to make presenters easy to use in views.
