### PR TITLE
Handle Nil objects in #present

### DIFF
--- a/lib/bourgeois/view_helper.rb
+++ b/lib/bourgeois/view_helper.rb
@@ -8,6 +8,7 @@ module Bourgeois
     #     puts user.name # => Remi
     #   end
     def present(object, klass = nil, &blk)
+      return if object.nil?
       return object.map { |o| present(o, klass, &blk) } if object.respond_to?(:to_a)
 
       if klass.blank?

--- a/spec/bourgeois/view_helper_spec.rb
+++ b/spec/bourgeois/view_helper_spec.rb
@@ -14,6 +14,21 @@ describe Bourgeois::ViewHelper do
       class User < OpenStruct; end
     end
 
+    context 'on a Nil object' do
+
+      context 'without a block' do
+        it { expect(view.present(nil)).not_to raise_error }
+      end
+
+      context 'with a block' do
+        specify do
+          expect {
+            view.present(nil) { |obj| obj.object_id }
+          }.not_to raise_error
+        end
+      end
+    end
+
     context 'on a single resource' do
       let(:user) { User.new first_name: 'Patrick', last_name: 'Bourgeois' }
 


### PR DESCRIPTION
Not sure if it was on purpose or not, but it feels more natural not to raise an error when a `Nil`object is passed to `#present` and to simply skip the whole call/block.
