### PR TITLE
Handle a Struct-based objects

### DIFF
--- a/lib/bourgeois/view_helper.rb
+++ b/lib/bourgeois/view_helper.rb
@@ -9,7 +9,7 @@ module Bourgeois
     #   end
     def present(object, klass = nil, &blk)
       return if object.nil?
-      return object.map { |o| present(o, klass, &blk) } if object.respond_to?(:to_a)
+      return object.map { |o| present(o, klass, &blk) } if object.respond_to?(:to_a) && !object.is_a?(Struct)
 
       if object.is_a?(Bourgeois::Presenter)
         presenter = object

--- a/spec/bourgeois/view_helper_spec.rb
+++ b/spec/bourgeois/view_helper_spec.rb
@@ -117,6 +117,24 @@ describe Bourgeois::ViewHelper do
       it { expect(presented_article.name).to eql 'LES B.B.' }
     end
 
+    context 'on a Struct-based resource' do
+      before do
+        class Band < Struct.new(:name)
+        end
+
+        class BandPresenter < Bourgeois::Presenter
+          def name
+            super.upcase
+          end
+        end
+      end
+
+      let(:band) { Band.new('Les B.B.') }
+      let(:presented_band) { view.present(band) }
+
+      it { expect(presented_band.name).to eql 'LES B.B.' }
+    end
+
     context 'on a collection of resources with a custom presenter class' do
       before do
         class Article < OpenStruct; end


### PR DESCRIPTION
Since `Struct`-based objects respond to `to_a` (by) and we were using `respond_to?(:to_a)` to check if we’re dealing with an array of objects or a single objects, we have to specifically check for `Struct` inheritance.
