### PR TITLE
Update/rails 5 n 2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ rvm:
 sudo: false
 
 gemfile:
-  - gemfiles/Gemfile.activemodel-4.0
+  - gemfiles/Gemfile.activemodel-5.1
+  - gemfiles/Gemfile.activemodel-4.2
   - gemfiles/Gemfile.activemodel-3.2.x
 
 script: "echo 'DO IT' && bundle exec rake spec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.1
-  - 2.0
-  - 1.9.3
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Bourgeois was inspired by some code [@rafBM](https://twitter.com/rafBM) wrote fo
 
 ## License
 
-`Bourgeois` is © 2013-2015 [Mirego](http://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause).  See the [`LICENSE.md`](https://github.com/mirego/bourgeois/blob/master/LICENSE.md) file.
+`Bourgeois` is © 2013-2017 [Mirego](http://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause).  See the [`LICENSE.md`](https://github.com/mirego/bourgeois/blob/master/LICENSE.md) file.
 
 ## About Mirego
 

--- a/gemfiles/Gemfile.activemodel-4.0
+++ b/gemfiles/Gemfile.activemodel-4.0
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activemodel', '~> 4.0.0'
-gem 'actionpack', '~> 4.0.0'

--- a/gemfiles/Gemfile.activemodel-4.2
+++ b/gemfiles/Gemfile.activemodel-4.2
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activemodel', '~> 4.2.0'
+gem 'actionpack', '~> 4.2.0'

--- a/gemfiles/Gemfile.activemodel-5.1
+++ b/gemfiles/Gemfile.activemodel-5.1
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activemodel', '~> 5.1.0'
+gem 'actionpack', '~> 5.1.0'


### PR DESCRIPTION
Update of test matrix & license year to keep it alive.  :love_letter:

Maybe we should drop rails 3.2 since its unsupported?

